### PR TITLE
improve performance for `Bun.sleepSync()` polyfill

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -118,10 +118,7 @@ if (process.isBun === undefined) {
     // bun.FFI (undocumented)
     // bun.match (undocumented)
     bun.sleepSync = (s: number) => {
-        //! This is truly horrible but what else can be done with pure JS
-        const ms = s * 1000;
-        const start = Date.now();
-        while (Date.now() - start < ms);
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, s * 1000);
     };
     // bun.fetch (undocumeted)
     // bun.getImportedStyles (undocumented)


### PR DESCRIPTION
This changes the existing implementation of `Bun.sleepSync()` from using a while loop to using a function i've never heard of before today: `Atomics.wait`.

I borrowed the code from https://www.npmjs.com/package/sleep-synchronously.

I tested it a little bit, enough to make sure it still works, but 
I didn't go so extensive to make sure that this also doesn't cause high cpu usage.

> "This is truly horrible but what else can be done with pure js"
> \- the original source

this
